### PR TITLE
Refine presets and ejection handling

### DIFF
--- a/three_body_problem.tsx
+++ b/three_body_problem.tsx
@@ -13,6 +13,16 @@ type Shard = {
   color: string;
 };
 
+type OuterObject = {
+  mass: number;
+  radius: number;
+  orbitCenter: [number, number];
+  orbitRadius: number;
+  omega: number;
+  phase: number;
+  color: string;
+};
+
 const orientationPresets: OrientationPreset[] = [
   {
     label: "Figure‑8",
@@ -40,33 +50,134 @@ const orientationPresets: OrientationPreset[] = [
       [0.570, -0.329],
     ],
   },
-  {
-    label: "Spiral",
-    p: [
-      [0.9, -0.2],
-      [-0.9, -0.2],
-      [0, 0.4],
-    ],
-    v: [
-      [-0.2, 0.5],
-      [-0.2, -0.5],
-      [0.4, 0],
-    ],
-  },
-  {
-    label: "Chain",
-    p: [
-      [-0.8, 0.2],
-      [0.8, -0.2],
-      [0, 0],
-    ],
-    v: [
-      [-0.1, 0.4],
-      [-0.1, -0.8],
-      [0.2, 0.4],
-    ],
-  },
 ];
+
+function randomOrientation(): OrientationPreset {
+  const rand = () => (Math.random() * 2 - 1) as number;
+  return {
+    label: "Random",
+    p: [
+      [rand(), rand()],
+      [rand(), rand()],
+      [rand(), rand()],
+    ],
+    v: [
+      [rand() * 0.5, rand() * 0.5],
+      [rand() * 0.5, rand() * 0.5],
+      [rand() * 0.5, rand() * 0.5],
+    ],
+  };
+}
+
+function createStarSystem(center: [number, number]): OuterObject[] {
+  const objs: OuterObject[] = [];
+  const star = {
+    mass: 4 + Math.random() * 3,
+    radius: 0.12 + Math.random() * 0.05,
+    orbitCenter: center,
+    orbitRadius: 0,
+    omega: 0,
+    phase: 0,
+    color: "#ffdd88",
+  };
+  objs.push(star);
+  const planetCount = 1 + Math.floor(Math.random() * 3);
+  for (let i = 0; i < planetCount; i++) {
+    const r = 2 + Math.random() * 3;
+    const omega = Math.sqrt(star.mass / Math.pow(r, 3));
+    objs.push({
+      mass: 0.2 + Math.random() * 0.3,
+      radius: 0.04 + Math.random() * 0.03,
+      orbitCenter: center,
+      orbitRadius: r,
+      omega,
+      phase: Math.random() * Math.PI * 2,
+      color: "#88aaff",
+    });
+  }
+  return objs;
+}
+
+function createTwinPlanets(center: [number, number]): OuterObject[] {
+  const objs: OuterObject[] = [];
+  const r = 0.6;
+  const m = 0.5;
+  const omega = Math.sqrt((2 * m) / Math.pow(r, 3));
+  objs.push({
+    mass: m,
+    radius: 0.07,
+    orbitCenter: center,
+    orbitRadius: r / 2,
+    omega,
+    phase: 0,
+    color: "#ffaa55",
+  });
+  objs.push({
+    mass: m,
+    radius: 0.07,
+    orbitCenter: center,
+    orbitRadius: r / 2,
+    omega,
+    phase: Math.PI,
+    color: "#55ffaa",
+  });
+  return objs;
+}
+
+function createAsteroidBelt(center: [number, number]): OuterObject[] {
+  const objs: OuterObject[] = [];
+  const beltR = 1.5 + Math.random();
+  const centralMass = 1;
+  const count = 6 + Math.floor(Math.random() * 6);
+  for (let i = 0; i < count; i++) {
+    const r = beltR + (Math.random() - 0.5) * 0.3;
+    const omega = Math.sqrt(centralMass / Math.pow(r, 3));
+    objs.push({
+      mass: 0.01,
+      radius: 0.02,
+      orbitCenter: center,
+      orbitRadius: r,
+      omega,
+      phase: Math.random() * Math.PI * 2,
+      color: "#aaaaaa",
+    });
+  }
+  return objs;
+}
+
+function generateClusterAround(center: [number, number]) {
+  const clusters: OuterObject[] = [];
+  const type = Math.floor(Math.random() * 3);
+  if (type === 0) clusters.push(...createStarSystem(center));
+  else if (type === 1) clusters.push(...createTwinPlanets(center));
+  else clusters.push(...createAsteroidBelt(center));
+  outerObjects.push(...clusters);
+}
+
+function outerObjectPosition(obj: OuterObject, t: number): [number, number] {
+  const [cx, cy] = obj.orbitCenter;
+  if (obj.orbitRadius === 0) return [cx, cy];
+  const ang = obj.phase + obj.omega * t;
+  return [cx + Math.cos(ang) * obj.orbitRadius, cy + Math.sin(ang) * obj.orbitRadius];
+}
+let outerObjects: OuterObject[] = [];
+const generatedRegions = new Set<string>();
+
+function ensureOuterObjectsAround(pos: [number, number]) {
+  const regionSize = 40;
+  const key = `${Math.floor(pos[0] / regionSize)},${Math.floor(pos[1] / regionSize)}`;
+  if (generatedRegions.has(key)) return;
+  generatedRegions.add(key);
+  const clusterCount = 2 + Math.floor(Math.random() * 3);
+  for (let i = 0; i < clusterCount; i++) {
+    const ang = Math.random() * Math.PI * 2;
+    const dist = 20 + Math.random() * 10;
+    const c: [number, number] = [pos[0] + Math.cos(ang) * dist, pos[1] + Math.sin(ang) * dist];
+    generateClusterAround(c);
+  }
+}
+
+ensureOuterObjectsAround([0, 0]);
 
 const defaultSettings = { zoom: 1.35, speedMul: 1, trail: 90 };
 
@@ -98,6 +209,11 @@ export default function ThreeBodyGlassSim() {
   // ======== Canvas / Animation Refs ========
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rafRef = useRef<number | null>(null);
+  const camOffsetRef = useRef<[number, number]>([0, 0]);
+  const followRef = useRef<number | null>(null);
+  const shatterPosRef = useRef<Array<[number, number] | null>>([null, null, null]);
+  const isDraggingRef = useRef(false);
+  const dragPosRef = useRef<[number, number]>([0, 0]);
 
   // ======== Physics / Simulation Refs ========
   const G = 1.0; // gravitational constant in sim units
@@ -180,7 +296,7 @@ export default function ThreeBodyGlassSim() {
   const dot = (a: number[], b: number[]) => a[0] * b[0] + a[1] * b[1];
   const norm = (a: number[]) => Math.hypot(a[0], a[1]);
 
-  function accelerations(p: [number, number][]) {
+  function accelerations(p: [number, number][], t: number, includeOuter: boolean) {
     const a: [number, number][] = [[0, 0], [0, 0], [0, 0]];
     for (let i = 0; i < 3; i++) {
       if (destroyedRef.current[i]) continue;
@@ -191,20 +307,30 @@ export default function ThreeBodyGlassSim() {
         const fac = (G * mass) / (d2 * d);
         a[i] = add(a[i], mul(r, fac));
       }
+      if (includeOuter) {
+        for (const obj of outerObjects) {
+          const pos = outerObjectPosition(obj, t);
+          const r = sub(pos, p[i]);
+          const d2 = r[0] * r[0] + r[1] * r[1] + softEps * softEps;
+          const d = Math.sqrt(d2);
+          const fac = (G * obj.mass) / (d2 * d);
+          a[i] = add(a[i], mul(r, fac));
+        }
+      }
     }
     return a;
   }
-  function rk4Step(p: [number, number][], v: [number, number][], dt: number) {
-    const a1 = accelerations(p);
+  function rk4Step(p: [number, number][], v: [number, number][], dt: number, t: number, includeOuter: boolean) {
+    const a1 = accelerations(p, t, includeOuter);
     const pv1 = p.map((pi, i) => add(pi, mul(v[i], dt * 0.5))) as [number, number][];
     const vv1 = v.map((vi, i) => add(vi, mul(a1[i], dt * 0.5))) as [number, number][];
-    const a2 = accelerations(pv1);
+    const a2 = accelerations(pv1, t + dt * 0.5, includeOuter);
     const pv2 = p.map((pi, i) => add(pi, mul(vv1[i], dt * 0.5))) as [number, number][];
     const vv2 = v.map((vi, i) => add(vi, mul(a2[i], dt * 0.5))) as [number, number][];
-    const a3 = accelerations(pv2);
+    const a3 = accelerations(pv2, t + dt * 0.5, includeOuter);
     const pv3 = p.map((pi, i) => add(pi, mul(vv2[i], dt))) as [number, number][];
     const vv3 = v.map((vi, i) => add(vi, mul(a3[i], dt))) as [number, number][];
-    const a4 = accelerations(pv3);
+    const a4 = accelerations(pv3, t + dt, includeOuter);
     const pNext = p.map((pi, i) => add(pi, mul(add(add(v[i], mul(add(vv1[i], vv2[i]), 2)), vv3[i]), dt / 6))) as [number, number][];
     const vNext = v.map((vi, i) => add(vi, mul(add(add(a1[i], mul(add(a2[i], a3[i]), 2)), a4[i]), dt / 6))) as [number, number][];
     return { p: pNext, v: vNext };
@@ -228,6 +354,25 @@ export default function ThreeBodyGlassSim() {
           const impulse = mul(n, vrn);
           v[i] = sub(v[i], impulse) as [number, number];
           v[j] = add(v[j], impulse) as [number, number];
+        }
+      }
+    }
+  }
+  function handleOuterCollisions(p: [number, number][], v: [number, number][], t: number) {
+    if (!preBufRef.current) return;
+    if (t < preBufRef.current.tEvent) return;
+    for (let i = 0; i < 3; i++) {
+      if (destroyedRef.current[i]) continue;
+      for (const obj of outerObjects) {
+        const pos = outerObjectPosition(obj, t);
+        const rij = sub(p[i], pos);
+        const d = norm(rij);
+        if (d <= radius + obj.radius) {
+          const n = mul(rij, 1 / (d || 1e-9));
+          const vrn = dot(v[i], n);
+          if (vrn < 0) {
+            v[i] = sub(v[i], mul(n, 2 * vrn)) as [number, number];
+          }
         }
       }
     }
@@ -259,6 +404,12 @@ export default function ThreeBodyGlassSim() {
     shardsRef.current = [];
     destroyedRef.current = [false, false, false];
     collisionHandledRef.current = false;
+    shatterPosRef.current = [null, null, null];
+    camOffsetRef.current = [0, 0];
+    followRef.current = null;
+    outerObjects = [];
+    generatedRegions.clear();
+    ensureOuterObjectsAround([0, 0]);
 
     // Base initial conditions from selected orientation
     let pBase = orientationRef.current.p.map((x) => [...x]) as [number, number][];
@@ -293,6 +444,8 @@ export default function ThreeBodyGlassSim() {
         let kind: "collision" | "ejection" = "collision";
         let info = "";
         let tEvent = 0;
+        let ejectCand: { k: number; step: number } | null = null;
+        const confirmSteps = 25000;
 
         for (let step = 0; step < maxSteps; step++) {
           buffer.push({ p: [[...p[0]], [...p[1]], [...p[2]]] as any, v: [[...v[0]], [...v[1]], [...v[2]]] as any });
@@ -313,19 +466,29 @@ export default function ThreeBodyGlassSim() {
             found = true; kind = "collision"; info = `${collidedPair[0] + 1}↔${collidedPair[1] + 1}`; tEvent = step * dt; break;
           }
 
-          // Ejection heuristic
+          // Ejection detection with permanence check
           const { pc } = centerOfMass(p);
           const pRel = p.map((pi) => sub(pi, pc));
           const vRel = v.map((vi) => vi);
           const R = pRel.map((ri) => norm(ri));
-          for (let k = 0; k < 3; k++) {
+          if (!ejectCand) {
+            for (let k = 0; k < 3; k++) {
+              const eSpec = energyOfBody(k, pRel as any, vRel as any);
+              const outward = dot(pRel[k], vRel[k]) > 0;
+              if (R[k] > 7.0 && outward && eSpec > 0) { ejectCand = { k, step }; break; }
+            }
+          } else {
+            const k = ejectCand.k;
             const eSpec = energyOfBody(k, pRel as any, vRel as any);
             const outward = dot(pRel[k], vRel[k]) > 0;
-            if (R[k] > 7.0 && outward && eSpec > 0) { found = true; kind = "ejection"; info = `body ${k + 1}`; tEvent = step * dt; break; }
+            if (R[k] < 5.0 || !outward || eSpec < 0) {
+              ejectCand = null;
+            } else if (step - ejectCand.step > confirmSteps) {
+              found = true; kind = "ejection"; info = `body ${k + 1}`; tEvent = ejectCand.step * dt; break;
+            }
           }
-          if (found) break;
 
-          const next = rk4Step(p as any, v as any, dt);
+          const next = rk4Step(p as any, v as any, dt, step * dt, false);
           p = next.p as any; v = next.v as any;
         }
 
@@ -355,6 +518,11 @@ export default function ThreeBodyGlassSim() {
       eventIndexRef.current = Math.floor(best.tEvent / dt);
       setEventType(best.kind);
       setEventBodyInfo(best.info);
+    }
+
+    if (preBufRef.current && opts?.targetRealTime) {
+      mapRef.current.baseSpeed = preBufRef.current.tEvent / opts.targetRealTime;
+      mapRef.current.realStart = performance.now() / 1000;
     }
 
     // Reset live state from pre-sim start
@@ -401,7 +569,8 @@ export default function ThreeBodyGlassSim() {
   function worldToScreen(x: number, y: number, W: number, H: number) {
     const s = scaleRef.current;
     const cx = W / 2, cy = H / 2;
-    return [cx + x * s, cy - y * s];
+    const [ox, oy] = camOffsetRef.current;
+    return [cx + (x - ox) * s, cy - (y - oy) * s];
   }
 
   // ======== Drawing ========
@@ -489,6 +658,19 @@ export default function ThreeBodyGlassSim() {
       ctx.fill();
       ctx.restore();
     }
+
+    // Outer celestial objects
+    for (const obj of outerObjects) {
+      const pos = outerObjectPosition(obj, liveRef.current.tSim);
+      const [x, y] = worldToScreen(pos[0], pos[1], W, H);
+      ctx.save();
+      glow(obj.color, 0.8);
+      ctx.fillStyle = obj.color;
+      ctx.beginPath();
+      ctx.arc(x, y, obj.radius * scaleRef.current, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
   }
 
   // ======== Animation Loop ========
@@ -524,6 +706,7 @@ export default function ThreeBodyGlassSim() {
             liveRef.current.v = exact.v.map((x) => [...x]) as any;
             liveRef.current.tSim = tEvent;
             if (buf.kind === "collision") handleCollision(liveRef.current.p as any, liveRef.current.v as any);
+            handleOuterCollisions(liveRef.current.p as any, liveRef.current.v as any, liveRef.current.tSim);
           }
         }
         if (!collisionHandledRef.current && buf.kind === "collision" && simTimeTarget > tEvent) {
@@ -537,6 +720,8 @@ export default function ThreeBodyGlassSim() {
           }
           destroyedRef.current[pair[0]] = true;
           destroyedRef.current[pair[1]] = true;
+          shatterPosRef.current[pair[0]] = [c[0], c[1]];
+          shatterPosRef.current[pair[1]] = [c[0], c[1]];
           liveRef.current.p[pair[0]] = [9999, 9999];
           liveRef.current.p[pair[1]] = [9999, 9999];
           liveRef.current.v[pair[0]] = [0, 0];
@@ -548,10 +733,11 @@ export default function ThreeBodyGlassSim() {
         const h = 0.005;
         while (dtLeft > 1e-6) {
           const step = Math.min(h, dtLeft);
-          const next = rk4Step(liveRef.current.p as any, liveRef.current.v as any, step);
+          const next = rk4Step(liveRef.current.p as any, liveRef.current.v as any, step, liveRef.current.tSim, true);
           liveRef.current.p = next.p as any;
           liveRef.current.v = next.v as any;
           handleCollision(liveRef.current.p as any, liveRef.current.v as any);
+          handleOuterCollisions(liveRef.current.p as any, liveRef.current.v as any, liveRef.current.tSim);
           for (const sh of shardsRef.current) {
             sh.p = add(sh.p, mul(sh.v, step)) as [number, number];
             sh.life -= step;
@@ -570,6 +756,20 @@ export default function ThreeBodyGlassSim() {
         if (destroyedRef.current[i]) continue;
         trailsRef.current[i].push([p[i][0], p[i][1]]);
         while (trailsRef.current[i].length > trailMax) trailsRef.current[i].shift();
+      }
+    }
+
+    if (preBufRef.current && liveRef.current.tSim >= preBufRef.current.tEvent) {
+      ensureOuterObjectsAround(camOffsetRef.current);
+      for (let i = 0; i < 3; i++) ensureOuterObjectsAround(liveRef.current.p[i]);
+      if (followRef.current !== null) {
+        const k = followRef.current;
+        if (destroyedRef.current[k]) {
+          const sp = shatterPosRef.current[k];
+          if (sp) camOffsetRef.current = [sp[0], sp[1]];
+        } else {
+          camOffsetRef.current = [liveRef.current.p[k][0], liveRef.current.p[k][1]];
+        }
       }
     }
 
@@ -604,6 +804,17 @@ export default function ThreeBodyGlassSim() {
     mapRef.current.realStart = performance.now() / 1000 - liveRef.current.tSim / (mapRef.current.baseSpeed * speedMul);
   }, [speedMul]);
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!preBufRef.current || liveRef.current.tSim < preBufRef.current.tEvent) return;
+      if (e.key === "1" || e.key === "2" || e.key === "3") {
+        followRef.current = parseInt(e.key) - 1;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
   // ======== Interactions ========
   function resetAll() {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
@@ -624,12 +835,34 @@ export default function ThreeBodyGlassSim() {
     setZoom(defaultSettings.zoom);
     setSpeedMul(defaultSettings.speedMul);
     setTrailMax(defaultSettings.trail);
+    camOffsetRef.current = [0, 0];
+    followRef.current = null;
+    outerObjects = [];
+    generatedRegions.clear();
+    ensureOuterObjectsAround([0, 0]);
   }
   function handleWheel(e: React.WheelEvent<HTMLDivElement>) {
     e.preventDefault();
     const factor = Math.pow(1.05, -e.deltaY / 100);
     userZoomRef.current = Math.max(0.5, Math.min(2.5, userZoomRef.current * factor));
     setZoom(userZoomRef.current);
+  }
+
+  function handleMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+    if (!preBufRef.current || liveRef.current.tSim < preBufRef.current.tEvent) return;
+    isDraggingRef.current = true;
+    dragPosRef.current = [e.clientX, e.clientY];
+    followRef.current = null;
+  }
+  function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
+    if (!isDraggingRef.current) return;
+    const dx = (e.clientX - dragPosRef.current[0]) / scaleRef.current;
+    const dy = (e.clientY - dragPosRef.current[1]) / scaleRef.current;
+    camOffsetRef.current = [camOffsetRef.current[0] - dx, camOffsetRef.current[1] + dy];
+    dragPosRef.current = [e.clientX, e.clientY];
+  }
+  function handleMouseUp() {
+    isDraggingRef.current = false;
   }
 
   function resetControls() {
@@ -687,7 +920,7 @@ export default function ThreeBodyGlassSim() {
             ))}
             <button
               onClick={() => {
-                const rand = orientationPresets[Math.floor(Math.random() * orientationPresets.length)];
+                const rand = randomOrientation();
                 orientationRef.current = rand;
                 setOrientation(rand);
               }}
@@ -711,7 +944,7 @@ export default function ThreeBodyGlassSim() {
               <button
                 key={opt.label}
                 onClick={() => {
-                  mapRef.current.baseSpeed = 0.35 + Math.random() * (1.5 - 0.35);
+                  mapRef.current.baseSpeed = 1;
                   setSpeedMul(defaultSettings.speedMul);
                   setTrailMax(defaultSettings.trail);
                   userZoomRef.current = defaultSettings.zoom;
@@ -730,7 +963,12 @@ export default function ThreeBodyGlassSim() {
   }
 
   return (
-    <div className="relative w-full h-[88vh] md:h-[92vh] bg-black text-white font-sans overflow-hidden rounded-2xl shadow-2xl" onWheel={handleWheel}>
+    <div className="relative w-full h-[88vh] md:h-[92vh] bg-black text-white font-sans overflow-hidden rounded-2xl shadow-2xl"
+      onWheel={handleWheel}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}>
       <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />
 
       {/* Top-left: Countdown glass panel */}


### PR DESCRIPTION
## Summary
- generate diverse random celestial clusters that populate new regions on demand
- enable post-event exploration with drag panning and key-based auto-follow of bodies or shatter points
- render through a camera offset so the map can be navigated across space

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c3199f7d5483309060872f96821112